### PR TITLE
Add translation stuff to support ViewGroups with scroll features (specifically ViewPager)

### DIFF
--- a/blurringview/src/main/java/com/fivehundredpx/android/blur/BlurringView.java
+++ b/blurringview/src/main/java/com/fivehundredpx/android/blur/BlurringView.java
@@ -62,7 +62,13 @@ public class BlurringView extends View {
                     mBitmapToBlur.eraseColor(Color.TRANSPARENT);
                 }
 
+                int scrollX = mBlurredView.getScrollX();
+                int scrollY = mBlurredView.getScrollY();
+
+                mBlurringCanvas.save();
+                mBlurringCanvas.translate(-scrollX, -scrollY);
                 mBlurredView.draw(mBlurringCanvas);
+                mBlurringCanvas.restore();
                 blur();
 
                 canvas.save();


### PR DESCRIPTION
This change enables the correct display of a blurred ViewPager. A translation applied to the blurringCanvas equal to the scroll amount was needed.
The blurring view still needs to be invalidated manually when viewpager scrolls.
