### PR TITLE
Allow BlurredView to be used in the Android Studio layout editor

### DIFF
--- a/blurringview/src/main/java/com/fivehundredpx/android/blur/BlurringView.java
+++ b/blurringview/src/main/java/com/fivehundredpx/android/blur/BlurringView.java
@@ -51,28 +51,30 @@ public class BlurringView extends View {
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
-        if (mBlurredView != null) {
-            if (prepare()) {
-                // If the background of the blurred view is a color drawable, we use it to clear
-                // the blurring canvas, which ensures that edges of the child views are blurred
-                // as well; otherwise we clear the blurring canvas with a transparent color.
-                if (mBlurredView.getBackground() != null && mBlurredView.getBackground() instanceof ColorDrawable){
-                    mBitmapToBlur.eraseColor(((ColorDrawable) mBlurredView.getBackground()).getColor());
-                }else {
-                    mBitmapToBlur.eraseColor(Color.TRANSPARENT);
-                }
-
-                mBlurredView.draw(mBlurringCanvas);
-                blur();
-
-                canvas.save();
-                canvas.translate(mBlurredView.getX() - getX(), mBlurredView.getY() - getY());
-                canvas.scale(mDownsampleFactor, mDownsampleFactor);
-                canvas.drawBitmap(mBlurredBitmap, 0, 0, null);
-                canvas.restore();
-            }
-            canvas.drawColor(mOverlayColor);
+        if (mBlurredView == null) {
+            return;
         }
+
+        if (prepare()) {
+            // If the background of the blurred view is a color drawable, we use it to clear
+            // the blurring canvas, which ensures that edges of the child views are blurred
+            // as well; otherwise we clear the blurring canvas with a transparent color.
+            if (mBlurredView.getBackground() != null && mBlurredView.getBackground() instanceof ColorDrawable) {
+                mBitmapToBlur.eraseColor(((ColorDrawable) mBlurredView.getBackground()).getColor());
+            } else {
+                mBitmapToBlur.eraseColor(Color.TRANSPARENT);
+            }
+
+            mBlurredView.draw(mBlurringCanvas);
+            blur();
+
+            canvas.save();
+            canvas.translate(mBlurredView.getX() - getX(), mBlurredView.getY() - getY());
+            canvas.scale(mDownsampleFactor, mDownsampleFactor);
+            canvas.drawBitmap(mBlurredBitmap, 0, 0, null);
+            canvas.restore();
+        }
+        canvas.drawColor(mOverlayColor);
     }
 
     public void setBlurRadius(int radius) {

--- a/blurringview/src/main/java/com/fivehundredpx/android/blur/BlurringView.java
+++ b/blurringview/src/main/java/com/fivehundredpx/android/blur/BlurringView.java
@@ -34,10 +34,15 @@ public class BlurringView extends View {
         final int defaultDownsampleFactor = res.getInteger(R.integer.default_downsample_factor);
         final int defaultOverlayColor = res.getColor(R.color.default_overlay_color);
 
-        initializeRenderScript(context);
+        final boolean isInEditMode = isInEditMode();
+        if (!isInEditMode) {
+            initializeRenderScript(context);
+        }
 
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.PxBlurringView);
-        setBlurRadius(a.getInt(R.styleable.PxBlurringView_blurRadius, defaultBlurRadius));
+        if (!isInEditMode) {
+            setBlurRadius(a.getInt(R.styleable.PxBlurringView_blurRadius, defaultBlurRadius));
+        }
         setDownsampleFactor(a.getInt(R.styleable.PxBlurringView_downsampleFactor,
                 defaultDownsampleFactor));
         setOverlayColor(a.getColor(R.styleable.PxBlurringView_overlayColor, defaultOverlayColor));
@@ -51,7 +56,13 @@ public class BlurringView extends View {
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
+
+        // If no view has been attached, there's nothing to do
         if (mBlurredView == null) {
+            // Though if we're being previewed in Android Studio, draw the overlay colour
+            if (isInEditMode()) {
+                canvas.drawColor(mOverlayColor);
+            }
             return;
         }
 


### PR DESCRIPTION
The layout preview UI can't handle code with Renderscript (among other things), so now we avoid those code paths if `BlurringView` is being rendered by the IDE.

This shouldn't affect runtime performance on a device in any way, as the `onDraw()` method only checks if it's running in an IDE — via the [`isInEditMode()`](https://developer.android.com/reference/android/view/View.html#isInEditMode%28%29) method — when no view-to-blur has been attached.

Without this, it's quite annoying to work with a layout that incorporates a `BlurringView`, as an error message continually pops up, obscuring part of the preview.

See the before / after screenshots:

[![blur_comparison](https://cloud.githubusercontent.com/assets/138615/8703954/50537cbc-2b20-11e5-9f42-0d428965fcff.png)](https://cloud.githubusercontent.com/assets/138615/8703958/56443bd4-2b20-11e5-9795-16462a062664.png)
(click to see larger error screenshot)
