### PR TITLE
Remove application tag from manifest.

### DIFF
--- a/blurringview/src/main/AndroidManifest.xml
+++ b/blurringview/src/main/AndroidManifest.xml
@@ -1,9 +1,1 @@
-<manifest
-    package="com.fivehundredpx.android.blur"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"/>
-
-</manifest>
+<manifest package="com.fivehundredpx.android.blur"/>


### PR DESCRIPTION
It is not needed and causes manifest merge conflicts.
